### PR TITLE
F-string + avoid unneeded config call in DM

### DIFF
--- a/highlight/highlight.py
+++ b/highlight/highlight.py
@@ -12,6 +12,8 @@ class Highlight(commands.Cog):
         self.config.register_channel(**default_channel)
 
     async def on_message(self, message):
+        if isinstance(message.channel, discord.abc.PrivateChannel):
+            return
         async with self.config.channel(message.channel).highlight() as highlight:
             for user in highlight:
                 if highlight[user].lower() in message.content:
@@ -36,7 +38,7 @@ class Highlight(commands.Cog):
            Note: 1 notification setting per channel."""
         async with self.config.channel(ctx.channel).highlight() as highlight:
             highlight[f"{ctx.author.id}"] = text
-            await ctx.send("The word `{text}` has been added to your highlight list..")
+            await ctx.send(f"The word `{text}` has been added to your highlight list.")
 
     @highlight.command()
     async def remove(self, ctx):


### PR DESCRIPTION
Added the f for an f-string that didn't have it, removed an extra period, and added a check if the message was in DM, to ignore it before querying Config.