### PR TITLE
[Unbelievaboat] Handle negatives in wallet deposit

### DIFF
--- a/unbelievaboat/unbelievaboat.py
+++ b/unbelievaboat/unbelievaboat.py
@@ -109,13 +109,13 @@ class Unbelievaboat(commands.Cog):
     async def bankdeposit(self, ctx, user, amount):
         conf = await self.configglobalcheckuser(user)
         wallet = await conf.wallet()
-        if amount > wallet:
+        if abs(amount) > wallet:
             return await ctx.send("You have insufficent funds to complete this deposit.")
         else:
-            await bank.deposit_credits(user, amount)
-            await self.walletset(user, wallet - amount)
+            await bank.deposit_credits(user, abs(amount))
+            await self.walletset(user, wallet - abs(amount))
             return await ctx.send(
-                f"You have succesfully deposited {amount} {await bank.get_currency_name(ctx.guild)} into your bank account."
+                f"You have succesfully deposited {abs(amount)} {await bank.get_currency_name(ctx.guild)} into your bank account."
             )
 
     async def walletbalance(self, user):


### PR DESCRIPTION
Unbelievaboat the bot does it this way where it will convert a negative value to a positive one. Currently there's an exception in wallet deposit if you use a negative value, which this resolves:
```
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/discord/ext/commands/core.py", line 79, in wrapped
    ret = await coro(*args, **kwargs)
  File "/.../Red-DiscordBot/cogs/CogManager/cogs/unbelievaboat/unbelievaboat.py", line 649, in deposit
    await self.bankdeposit(ctx, ctx.author, amount)
  File "/.../Red-DiscordBot/cogs/CogManager/cogs/unbelievaboat/unbelievaboat.py", line 115, in bankdeposit
    await bank.deposit_credits(user, amount)
  File "/.../lib/python3.7/site-packages/redbot/core/bank.py", line 279, in deposit_credits
    raise ValueError("Invalid deposit amount {} <= 0".format(amount))
ValueError: Invalid deposit amount -1 <= 0
```