### PR TITLE
[Forward] Adds channel notifications instead of bot owner DMs + little changes

### DIFF
--- a/forward/info.json
+++ b/forward/info.json
@@ -3,11 +3,11 @@
     "flare(flare#0001)",
     "Aikaterna"
   ],
-  "install_msg": "Forward messages to the bot owner.",
+  "install_msg": "Forward messages sent to the bot to the bot owner or in a specified channel.",
   "name": "Forward",
   "disabled": false,
-  "short": "Forward messages to bot owner.",
-  "description": "Forward DMs to the bot to the bot owner.",
+  "short": "Forward messages sent to the bot to the bot owner or in a specified channel.",
+  "description": "Forward messages sent to the bot to the bot owner or in a specified channel.",
   "tags": [
     "forward",
     "forwarding"


### PR DESCRIPTION
- Add the possibility to receive the notifications to a specified channel instead of bot owner DMs.
- Use `.to_dict()` method to get embed data if they exist instead of set everything manually.
- Add the possibility to mention a member when using `[p]pm` command.