### PR TITLE
Log actions from third-party cogs as commands.

### DIFF
--- a/commandstats/commandstats.py
+++ b/commandstats/commandstats.py
@@ -40,26 +40,36 @@ class CommandStats(commands.Cog):
         asyncio.create_task(self.update_data())
         asyncio.create_task(self.update_global())
 
-    @commands.Cog.listener()
-    async def on_command(self, ctx):
-        command = str(ctx.command)
+    def record(self, ctx, name):
         guild = ctx.message.guild
         if not ctx.message.author.bot:
             if guild is not None:
                 if str(guild.id) not in self.cache["guild"]:
                     self.cache["guild"][str(guild.id)] = Counter({})
-                if command not in self.cache["guild"][str(guild.id)]:
-                    self.cache["guild"][str(guild.id)][command] = 1
+                if name not in self.cache["guild"][str(guild.id)]:
+                    self.cache["guild"][str(guild.id)][name] = 1
                 else:
-                    self.cache["guild"][str(guild.id)][command] += 1
-            if command not in self.cache["session"]:
-                self.cache["session"][command] = 1
+                    self.cache["guild"][str(guild.id)][name] += 1
+            if name not in self.cache["session"]:
+                self.cache["session"][name] = 1
             else:
-                self.cache["session"][command] += 1
-            if command not in self.session:
-                self.session[command] = 1
+                self.cache["session"][name] += 1
+            if name not in self.session:
+                self.session[name] = 1
             else:
-                self.session[command] += 1
+                self.session[name] += 1
+
+    @commands.Cog.listener()
+    async def on_command(self, ctx):
+        """Record standard command events."""
+        name = str(ctx.command)
+        self.record(ctx, name)
+
+    @commands.Cog.listener()
+    async def on_commandstats_action(self, ctx):
+        """Record action events (i.e. other cog emits 'commandstats_action')."""
+        name = str(ctx.command)
+        self.record(ctx, name)
 
     @commands.is_owner()
     @commands.group(invoke_without_command=True)


### PR DESCRIPTION
This PR supports receiving events from third-party cogs to log as if they were commands. This is useful for counting user interactions with the bot via reaction buttons or any other action that is not itself a command.

The interface is pretty simple: the cog should just dispatch the custom event `commandstats_action` with ctx as its argument. See:

https://github.com/synrg/dronefly/issues/96

The simplest case of inatcog's use of this interface is here:

https://github.com/synrg/dronefly/blob/af71063d0760cd7fe33f26289b024db9b890b488/inatcog/listeners.py#L92-L95

The `on_message_without_command()` handler treats the user's message as if it were a command to automatically preview a link pasted into the channel. Because it's in an `on` handler, it synthesizes `ctx` with enough of the Context to satisfy `commandstats`. For instance, the PartialContext it supplies responds to `ctx.message.author.bot` & `ctx.message.guild`. Also, `str(ctx.command)` works because ctx.command is simply set to a string. I realize this could change in future, so it's up to any cog developer making use of this interface to watch changes to commandstats in future versions and fix their partial Context accordingly. For example, the command string might later need to be replaced with a PartialCommand or a full Command object to support more sophisticated stats collection.