### PR TITLE
[Covid] fix for "Critical" + new "Recovered Today" field

### DIFF
--- a/covid/covid.py
+++ b/covid/covid.py
@@ -147,6 +147,7 @@ class Covid(commands.Cog):
             )
             embed.add_field(name="Cases Today", value=humanize_number(data["todayCases"]))
             embed.add_field(name="Deaths Today", value=humanize_number(data["todayDeaths"]))
+            embed.add_field(name="Recovered Today", value=humanize_number(data["todayRecovered"]))
             embed.add_field(name="Total Tests", value=humanize_number(data["tests"]))
             await ctx.send(embed=embed)
         else:
@@ -182,7 +183,18 @@ class Covid(commands.Cog):
                     if country["todayDeaths"] is not None
                     else "Not reported/None",
                 )
-                embed.add_field(name="Critical", value=humanize_number(country["critical"]))
+                embed.add_field(
+                    name="Recovered Today",
+                    value=humanize_number(country["todayRecovered"])
+                    if country["todayRecovered"] is not None
+                    else "Not reported/None",
+                )
+                embed.add_field(
+                    name="Critical",
+                    value=humanize_number(country["critical"])
+                    if country["critical"] is not None
+                    else "Not reported/None",
+                )
                 embed.add_field(name="Active", value=humanize_number(country["active"]))
                 embed.add_field(name="Total Tests", value=humanize_number(country["tests"]))
                 embed.add_field(name="\u200b", value="\u200b")


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This fixes the issue when value for "Critical" key in JSON returned by API can be "null" for `[p]covid [country]` command.
Also added new "Recovered Today" field in `[p]covid` command output, because I see the API also returns this data in JSON and I think this would make the covid stats tad more informative.
Please let me know what do you think.