### PR TITLE
Fix detection of embed

### DIFF
--- a/embedcreator/embedcreator.py
+++ b/embedcreator/embedcreator.py
@@ -124,7 +124,7 @@ class EmbedCreator(commands.Cog):
             return await ctx.send(
                 "Oops. An error occured turning the input to an embed. Please validate the file and ensure it is using the correct keys."
             )
-        if not embed:
+        if not isinstance(embed, discord.Embed):
             return await ctx.send("Embed could not be built from the json provided.")
         await channel.send(embed=embed)
 
@@ -147,7 +147,7 @@ class EmbedCreator(commands.Cog):
             return await ctx.send(
                 "Oops. An error occured turning the input to an embed. Please validate the file and ensure it is using the correct keys."
             )
-        if not embed:
+        if not isinstance(embed, discord.Embed):
             return await ctx.send("Embed could not be built from the json provided.")
         await ctx.send("Here's how this will look.", embed=embed)
         async with self.config.guild(ctx.guild).embeds() as embeds:


### PR DESCRIPTION
Trying to create a embed with just a image fails the current detection, it would have been a valid embed, but not pass the detection.

```json
{
    "image": {
        "url": "https://github.com/Roxedus.png"
    },
    "color": 7562986,
    "type": "rich"
}
```

The JSON is valid, generating the same embed in discord.py and printing the result of to_dict() yields the same JSON.

```py
test_embed = discord.Embed(colour=7562986)
test_embed.set_image(url="https://github.com/Roxedus.png")
js = test_embed.to_dict()
await ctx.send(f"\`\`\`json\n{json.dumps(js)}\`\`\`")
await ctx.send(embed=test_embed)
```