### PR TITLE
[CommandStats] bugfix

### DIFF
--- a/commandstats/commandstats.py
+++ b/commandstats/commandstats.py
@@ -173,8 +173,9 @@ class CommandStats(commands.Cog):
             server = ctx.guild
         await self.update_data()
         data = await self.config.guilddata()
-        data = data[str(server.id)]
-        if not data:
+        try:
+            data = data[str(server.id)]
+        except KeyError:
             return await ctx.send(f"No commands have been used in {server.name} yet.")
         if command is None:
             await GenericMenu(


### PR DESCRIPTION
This fixes a bug with `[p]cmd guild <guild>` when there can be no data of that target guild in cog's config. You can reproduce it by adding your bot in a new guild and try to fetch cmdstats of that guild or of a guild where no commands have ever been used.

```py
Traceback (most recent call last):
  File "/home/ubuntu/merlin/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/merlin/cogs/CogManager/cogs/commandstats/commandstats.py", line 176, in guild
    data = data[str(server.id)]
KeyError: '213005040934322177'
```