### PR TITLE
[AntiSpam] Update docstrings for better explanation of time

### DIFF
--- a/antispam/antispam.py
+++ b/antispam/antispam.py
@@ -132,6 +132,8 @@ class AntiSpam(commands.Cog):
             `[p]antispamset length 1d2h30m`
             `[p]antispamset length 1 day 2 hours 30 minutes`
         """
+        if not length:
+            return await ctx.send("You must provide a value greater than 0.")
         duration_seconds = length.total_seconds()
         await self.config.mute_length.set(duration_seconds)
         await ctx.send(

--- a/antispam/antispam.py
+++ b/antispam/antispam.py
@@ -125,7 +125,13 @@ class AntiSpam(commands.Cog):
 
     @antispamset.command()
     async def length(self, ctx, *, length: TimedeltaConverter):
-        """How long to blacklist a user from using commands."""
+        """How long to blacklist a user from using commands.
+
+        Accepts: seconds, minutes, hours, days, weeks
+        Examples:
+            `[p]antispamset length 1d2h30m`
+            `[p]antispamset length 1 day 2 hours 30 minutes`
+        """
         duration_seconds = length.total_seconds()
         await self.config.mute_length.set(duration_seconds)
         await ctx.send(
@@ -135,7 +141,15 @@ class AntiSpam(commands.Cog):
 
     @antispamset.command()
     async def per(self, ctx, *, length: TimedeltaConverter):
-        """How long of a timeframe to keep track of command spamming."""
+        """How long of a timeframe to keep track of command spamming.
+
+        Accepts: seconds, minutes, hours, days, weeks
+        Examples:
+            `[p]antispamset per 1d2h30m`
+            `[p]antispamset per 1 day 2 hours 30 minutes`
+        """
+        if not length:
+            return await ctx.send("You must provide a value greater than 0.")
         duration_seconds = length.total_seconds()
         await self.config.per.set(duration_seconds)
         await ctx.send(

--- a/antispam/antispam.py
+++ b/antispam/antispam.py
@@ -14,7 +14,7 @@ log = logging.getLogger("red.flare.antispam")
 class AntiSpam(commands.Cog):
     """Blacklist those who spam commands."""
 
-    __version__ = "0.0.9"
+    __version__ = "0.0.10"
     __author__ = "flare#0001"
 
     def format_help_for_context(self, ctx):


### PR DESCRIPTION
I was having some trouble understanding what the TimedeltaConverter wanted for length before I looked up the code in Red. This change attempts to explain the units to users a bit more.