### PR TITLE
[redditpost] fix for case sensitive subreddit name matching in config

### DIFF
--- a/redditpost/redditpost.py
+++ b/redditpost/redditpost.py
@@ -106,7 +106,7 @@ class RedditPost(commands.Cog):
         subreddit = subreddit.lstrip("/")
         match = REDDIT_REGEX.fullmatch(subreddit)
         if match:
-            return match.groups()[-1].lower()
+            return match.groups()[-1]
         return None
 
     @commands.admin_or_permissions(manage_channels=True)
@@ -340,7 +340,7 @@ class RedditPost(commands.Cog):
             embed = discord.Embed(
                 title=unescape(title),
                 url=unescape(link),
-                description=desc,
+                description="{}".format(desc).replace("&#x200B;", ""),
                 color=channel.guild.me.color,
                 timestamp=datetime.utcfromtimestamp(feed["created_utc"]),
             )


### PR DESCRIPTION
This fixes a bug when added sub name is case sensitive and bot can't find it in config because it was trying to match sub name in lower case.
![unknown](https://cdn.discordapp.com/attachments/133251234164375552/771783468291063818/Screenshot_20201030-224050_Discord.png)

also properly replaces html/xml character like `&#x200B;` which unescape is not able to replace, to prevent this:
![unescape-fail](https://user-images.githubusercontent.com/24418520/99078044-b63a2580-25e3-11eb-9c5f-14c6c477372f.png)

wondering why I forgot to PR this after our discussion, sorry.