### PR TITLE
[Forward] Respect type when it's passed in `forwardset botmsg`

### DIFF
--- a/forward/forward.py
+++ b/forward/forward.py
@@ -98,7 +98,8 @@ class Forward(commands.Cog):
         Type must be a valid bool.
         """
         async with self.config.toggles() as toggles:
-            type = not toggles.get("botmessages")
+            if type is None:
+                type = not toggles.get("botmessages")
             if type:
                 toggles["botmessages"] = True
                 await ctx.send("Bot message notifications have been enabled.")


### PR DESCRIPTION
this command would take a bool option and end up completely ignoring it if passed, resulting in confusing behavior
![image](https://user-images.githubusercontent.com/23347632/115896692-ebf7fb80-a418-11eb-8f64-ff4ad6a39856.png)
