### PR TITLE
Fix snipe continuation when there's no message content

### DIFF
--- a/snipe/snipe.py
+++ b/snipe/snipe.py
@@ -173,9 +173,12 @@ class Snipe(commands.Cog):
             await ctx.guild.chunk()
         author = ctx.guild.get_member(channelsnipe["author"])
         content = list(pagify(channelsnipe["content"]))
-        embed = discord.Embed(
+        if content:
             description=content[0]
-            or "No message content.\nThe deleted message may have been an image or an embed.",
+        else:
+            description="No message content.\nThe deleted message may have been an image or an embed."
+        embed = discord.Embed(
+            description=description
             timestamp=channelsnipe["timestamp"],
             color=ctx.author.color,
         )

--- a/snipe/snipe.py
+++ b/snipe/snipe.py
@@ -174,9 +174,11 @@ class Snipe(commands.Cog):
         author = ctx.guild.get_member(channelsnipe["author"])
         content = list(pagify(channelsnipe["content"]))
         if content:
-            description=content[0]
+            description = content[0]
         else:
-            description="No message content.\nThe deleted message may have been an image or an embed."
+            description = (
+                "No message content.\nThe deleted message may have been an image or an embed."
+            )
         embed = discord.Embed(
             description=description,
             timestamp=channelsnipe["timestamp"],

--- a/snipe/snipe.py
+++ b/snipe/snipe.py
@@ -178,7 +178,7 @@ class Snipe(commands.Cog):
         else:
             description="No message content.\nThe deleted message may have been an image or an embed."
         embed = discord.Embed(
-            description=description
+            description=description,
             timestamp=channelsnipe["timestamp"],
             color=ctx.author.color,
         )


### PR DESCRIPTION
```py
Traceback (most recent call last):
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/main/red/cogs/CogManager/cogs/snipe/snipe.py", line 177, in snipe
    description=content[0]
IndexError: list index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: IndexError: list index out of range
```