### PR TITLE
[Tips] Fix and simplify monkeypatch

### DIFF
--- a/tips/tips.py
+++ b/tips/tips.py
@@ -20,6 +20,7 @@ class Default(dict):
     """Used with str.format_map to avoid KeyErrors on bad tips."""
 
     def __missing__(self, key):
+        # returns missing keys as '{key}'
         return f"{{{key}}}"
 
 


### PR DESCRIPTION
From https://discord.com/channels/240154543684321280/249915052130435074/856935319819124766

This prevents the `Context.send` monkeypatch from raising KeyErrors by using `str.format_map`, and also simplifies its logic.