### PR TITLE
[RedditPost] url -> subreddit

### DIFF
--- a/redditpost/redditpost.py
+++ b/redditpost/redditpost.py
@@ -202,7 +202,7 @@ class RedditPost(commands.Cog):
                 return await ctx.send(f"That didn't seem to be a valid reddit feed.")
 
             feeds[subreddit] = {
-                "url": subreddit,
+                "subreddit": subreddit,
                 "last_post": datetime.now().timestamp(),
                 "latest": True,
                 "logo": logo,


### PR DESCRIPTION
The new changes resulted in a `subreddit` key being added to old settings, but new ones still use `url`, resulting in an error