### PR TITLE
[RedditPost] Fix init

### DIFF
--- a/redditpost/__init__.py
+++ b/redditpost/__init__.py
@@ -5,5 +5,4 @@ __red_end_user_data_statement__ = "This cog does not persistently store data abo
 
 async def setup(bot):
     cog = RedditPost(bot)
-    await cog.init()
     bot.add_cog(cog)

--- a/redditpost/redditpost.py
+++ b/redditpost/redditpost.py
@@ -42,6 +42,7 @@ class RedditPost(commands.Cog):
         self.bg_loop_task: Optional[asyncio.Task] = None
         self.notified = False
         self.client = None
+        self.bot.loop.create_task(self.init())
 
     async def red_get_data_for_user(self, *, user_id: int):
         # this cog does not story any data
@@ -52,6 +53,7 @@ class RedditPost(commands.Cog):
         pass
 
     async def init(self):
+        await self.bot.wait_until_red_ready()
         if await self.config.SCHEMA_VERSION() == 1:
             data = await self.config.all_channels()
             for channel, _ in data.items():


### PR DESCRIPTION
This PR moves the starting of the init function to after the cog is loaded. 
This way, we can wait_until_red_ready which avoids this error on bot restart:
https://sentry.io/share/issue/a3dbb5be314648c8804f3c81d2449279/