### PR TITLE
[forward] Fix Optional recipient

### DIFF
--- a/forward/forward.py
+++ b/forward/forward.py
@@ -57,7 +57,15 @@ class Forward(commands.Cog):
     async def on_message_without_command(self, message):
         if message.guild is not None:
             return
-        if message.channel.recipient.id in self.bot.owner_ids:
+        recipient = message.channel.recipient
+        if recipient is None:
+            chan = self.bot.get_channel(message.channel.id)
+            if chan is None:
+                chan = await self.bot.fetch_channel(message.channel.id)
+            if not isinstance(chan, discord.DMChannel):
+                return
+            recipient = chan.recipient
+        if recipient.id in self.bot.owner_ids:
             return
         if not await self.bot.allowed_by_whitelist_blacklist(message.author):
             return
@@ -68,7 +76,7 @@ class Forward(commands.Cog):
             async with self.config.toggles() as toggle:
                 if not toggle["botmessages"]:
                     return
-            msg = f"Sent PM to {message.channel.recipient} (`{message.channel.recipient.id}`)"
+            msg = f"Sent PM to {recipient} (`{recipient.id}`)"
             if message.embeds:
                 msg += f"\n**Message Content**: {message.content}"
                 embeds = [


### PR DESCRIPTION
this pr fixes 2 thing linked to the fact that recipient is now optional in dpy2:
 - When a bot sends a message to a dmchannel, its recipient is None, so we fix that by fetching the channel via its id
 - Ephemeral message sent in response to an interaction don't have a guild since their channel is a DMChannel but its id is one of a GuildChannel, so if we fetch it, we'll get a channel that doesn't have a recipient, the way i fixed that is by discarding the message if its fetched channel isn't a DMChannel
 
 This pr was tested without problems with an account that wasn't the bot owner