### PR TITLE
[userinfo] fix AttributeError if adventure loaded

### DIFF
--- a/userinfo/userinfo.py
+++ b/userinfo/userinfo.py
@@ -344,7 +344,7 @@ class Userinfo(commands.Cog):
                         global adventure_bank
                         if adventure_bank is None:
                             try:
-                                from adventure import bank as adventure_bank
+                                from adventure.bank import bank as adventure_bank
                             except:
                                 pass
                         if adventure_bank:


### PR DESCRIPTION
Bot was throwing an exception
```py
Traceback (most recent call last):
--
2 | File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 229, in wrapped
3 | ret = await coro(*args, **kwargs)
4 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
5 | File "/home/ubuntu/data/starship_main/cogs/CogManager/cogs/userinfo/userinfo.py", line 351, in userinfo
6 | adventure_currency = await adventure_bank.get_balance(user)
7 | ^^^^^^^^^^^^^^^^^^^^^^^^^^
8 | AttributeError: module 'adventure.bank' has no attribute 'get_balance'
9 |  
10 | The above exception was the direct cause of the following exception:
11 |  
12 | Traceback (most recent call last):
13 | File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/bot.py", line 1350, in invoke
14 | await ctx.command.invoke(ctx)
15 | File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1023, in invoke
16 | await injected(*ctx.args, **ctx.kwargs)  # type: ignore
17 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
18 | File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 238, in wrapped
19 | raise CommandInvokeError(exc) from exc
20 | discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: module 'adventure.bank' has no attribute 'get_balance'
```

