### PR TITLE
[trigger] Add support for trigger on embed contents with toggle

### DIFF
--- a/trigger/objects.py
+++ b/trigger/objects.py
@@ -16,6 +16,7 @@ class TriggerObject:
         self.toggle = kwargs.get("toggle", False)
         self.case_sensitive = kwargs.get("case_sensitive", True)
         self.word_boundary = kwargs.get("word_boundary", False)
+        self.embed_search = kwargs.get("embed_search", False)
         self.pattern = None
 
     def check(self, message):
@@ -28,33 +29,35 @@ class TriggerObject:
             trigger = trigger.lower()
             content = content.lower()
 
+        if self.cooldown > 0:
+            if self.timestamp is None:
+                self.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+            else:
+                now = datetime.datetime.now(tz=datetime.timezone.utc)
+                diff = now - self.timestamp
+                if diff.total_seconds() < self.cooldown:
+                    return False
+                else:
+                    self.timestamp = now
+
         if self.word_boundary:
             if self.pattern is None:
                 self.pattern = re.compile(rf"\b{re.escape(self.trigger.lower())}\b", flags=re.I)
-            if set(self.pattern.findall(content)):
-                if self.cooldown > 0:
-                    if self.timestamp is None:
-                        self.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
-                    else:
-                        now = datetime.datetime.now(tz=datetime.timezone.utc)
-                        diff = now - self.timestamp
-                        if diff.total_seconds() < self.cooldown:
-                            return False
-                        else:
-                            self.timestamp = now
+            if self.pattern.search(content):
                 return True
         elif trigger in content:
-            if self.cooldown > 0:
-                if self.timestamp is None:
-                    self.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
-                else:
-                    now = datetime.datetime.now(tz=datetime.timezone.utc)
-                    diff = now - self.timestamp
-                    if diff.total_seconds() < self.cooldown:
-                        return False
-                    else:
-                        self.timestamp = now
             return True
+        elif self.embed_search:
+            print("Entered")
+            embeds = message.embeds
+            if len(embeds) > 0:
+                embed_dict_list = []
+                for embed in embeds:
+                    embed_dict_list.append(embed.to_dict())
+                if self.pattern is None:
+                    self.pattern = re.compile(rf"{re.escape(self.trigger.lower())}", flags=re.I)
+                if self.pattern.findall(str(embed_dict_list)):
+                    return True
         return False
 
     async def respond(self, message):

--- a/trigger/trigger.py
+++ b/trigger/trigger.py
@@ -131,6 +131,7 @@ class Trigger(commands.Cog):
                 "toggle": True,
                 "case_sensitive": False,
                 "word_boundary": False,
+                "embed_search": False,
             }
             await self.update_trigger(ctx.guild, trigger_name, triggers[trigger_name])
 
@@ -256,6 +257,20 @@ class Trigger(commands.Cog):
                 await ctx.send("Trigger does not exist.")
                 return
             triggers[trigger_name]["word_boundary"] = toggle
+            await self.update_trigger(ctx.guild, trigger_name, triggers[trigger_name])
+        await ctx.tick()
+
+    @edit.command(name="embeds", aliases=["embedsearch"])
+    async def embed_search(self, ctx, trigger_name: str, toggle: bool):
+        """
+        Toggle searching within embeds for the trigger.
+        """
+        trigger_name = trigger_name.lower()
+        async with self.config.guild(ctx.guild).triggers() as triggers:
+            if trigger_name not in triggers:
+                await ctx.send("Trigger does not exist.")
+                return
+            triggers[trigger_name]["embed_search"] = toggle
             await self.update_trigger(ctx.guild, trigger_name, triggers[trigger_name])
         await ctx.tick()
 


### PR DESCRIPTION
- Add toggle option to enable searching in embeds for triggers. 
- Changed re.findall to re.search as you don't need to return all occurrences, this way the search stops as soon as it finds the string instead of crawling the whole contents. 
- Moved the cooldown check outside of the search as all three search checks use it and there is no need for the string search if the cooldown hasn't been met. A potential alternative is to move it out to it's own function.