### PR TITLE
[Userinfo] Fix `userinfo` not working on Red 3.5.3

### DIFF
--- a/userinfo/info.json
+++ b/userinfo/info.json
@@ -10,5 +10,5 @@
     "tags": [
         "userinfo"
     ],
-    "min_bot_version": "3.5.0"
+    "min_bot_version": "3.5.3"
 }

--- a/userinfo/userinfo.py
+++ b/userinfo/userinfo.py
@@ -195,7 +195,7 @@ class Userinfo(commands.Cog):
                 }
             )
             roles = user.roles[-1:0:-1]
-            names, nicks = await mod.get_names_and_nicks(user)
+            usernames, display_names, nicks = await mod.get_names(user)
 
             joined_at = user.joined_at
             since_created = int((ctx.message.created_at - user.created_at).days)
@@ -284,10 +284,14 @@ class Userinfo(commands.Cog):
             data.add_field(name="Joined this server on", value=joined_on)
             if role_str is not None:
                 data.add_field(name="Roles", value=role_str, inline=False)
-            if names:
+            if usernames:
                 # May need sanitizing later, but mentions do not ping in embeds currently
-                val = filter_invites(", ".join(names))
-                data.add_field(name="Previous Names", value=val, inline=False)
+                val = filter_invites(", ".join(usernames))
+                data.add_field(name="Previous Usernames", value=val, inline=False)
+            if display_names:
+                # May need sanitizing later, but mentions do not ping in embeds currently
+                val = filter_invites(", ".join(display_names))
+                data.add_field(name="Previous Display Names", value=val, inline=False)
             if nicks:
                 # May need sanitizing later, but mentions do not ping in embeds currently
                 val = filter_invites(", ".join(nicks))


### PR DESCRIPTION
Fixes userinfo throwing an exception due to the changes made [here](https://github.com/Cog-Creators/Red-DiscordBot/commit/10e09d6abcf925544b0ab6965f4cb04b69a30070#diff-8fd2d641da6d7a0358dbc60abe89b5a6f3a8794f6db791e8f9815beb5f3b5614L23-R31)