### PR TITLE
Update converters.py

### DIFF
--- a/stickbugged/converters.py
+++ b/stickbugged/converters.py
@@ -36,13 +36,13 @@ class ImageFinder(Converter):
             for mention in mentions:
                 user = ctx.guild.get_member(int(mention.group(1)))
                 if user is not None:
-                    url = IMAGE_LINKS.search(str(user.display_avatar.replace(format="png").url))
+                    url = IMAGE_LINKS.search(str(user.display_avatar.replace(size=512, static_format="png").url))              
                     urls.append(url.group(1))
         if not urls and ids:
             for possible_id in ids:
                 user = ctx.guild.get_member(int(possible_id.group(0)))
                 if user:
-                    url = IMAGE_LINKS.search(str(user.display_avatar.replace(format="png").url))
+                    url = IMAGE_LINKS.search(str(user.display_avatar.replace(size=512, static_format="png").url))    
                     urls.append(url.group(1))
         if attachments:
             for attachment in attachments:
@@ -51,7 +51,7 @@ class ImageFinder(Converter):
         if not urls and ctx.guild:
             user = ctx.guild.get_member_named(argument)
             if user:
-                url = user.display_avatar.replace(format="png").url
+                url = IMAGE_LINKS.search(str(user.display_avatar.replace(size=512, static_format="png").url))    
                 urls.append(url)
         if not urls:
             raise BadArgument("No images found.")

--- a/stickbugged/converters.py
+++ b/stickbugged/converters.py
@@ -36,13 +36,17 @@ class ImageFinder(Converter):
             for mention in mentions:
                 user = ctx.guild.get_member(int(mention.group(1)))
                 if user is not None:
-                    url = IMAGE_LINKS.search(str(user.display_avatar.replace(size=512, static_format="png").url))              
+                    url = IMAGE_LINKS.search(
+                        str(user.display_avatar.replace(size=512, static_format="png").url)
+                    )
                     urls.append(url.group(1))
         if not urls and ids:
             for possible_id in ids:
                 user = ctx.guild.get_member(int(possible_id.group(0)))
                 if user:
-                    url = IMAGE_LINKS.search(str(user.display_avatar.replace(size=512, static_format="png").url))    
+                    url = IMAGE_LINKS.search(
+                        str(user.display_avatar.replace(size=512, static_format="png").url)
+                    )
                     urls.append(url.group(1))
         if attachments:
             for attachment in attachments:
@@ -51,7 +55,9 @@ class ImageFinder(Converter):
         if not urls and ctx.guild:
             user = ctx.guild.get_member_named(argument)
             if user:
-                url = IMAGE_LINKS.search(str(user.display_avatar.replace(size=512, static_format="png").url))    
+                url = IMAGE_LINKS.search(
+                    str(user.display_avatar.replace(size=512, static_format="png").url)
+                )
                 urls.append(url)
         if not urls:
             raise BadArgument("No images found.")


### PR DESCRIPTION
- Add fixed avatar size of 512, to prevent default videos export at 128x128
![image](https://github.com/flaree/flare-cogs/assets/48269777/8dca5b32-ee85-4d87-ab8d-4bb73a9a6660)
