### PR TITLE
[unbelievaboat] fix a edge case in rob

### DIFF
--- a/unbelievaboat/unbelievaboat.py
+++ b/unbelievaboat/unbelievaboat.py
@@ -398,7 +398,7 @@ class Unbelievaboat(Wallet, Roulette, SettingsMixin, commands.Cog, metaclass=Com
             embed.set_author(name=ctx.author, icon_url=ctx.author.display_avatar)
             return await ctx.send(embed=embed)
         modifier = roll()
-        stolen = random.randint(1, int(userbalance * modifier)+1)
+        stolen = random.randint(1, int(userbalance * modifier) + 1)
         embed = discord.Embed(
             colour=discord.Color.green(),
             description=f"You steal {user.name}'s wallet and find {humanize_number(stolen)} inside.",

--- a/unbelievaboat/unbelievaboat.py
+++ b/unbelievaboat/unbelievaboat.py
@@ -398,7 +398,7 @@ class Unbelievaboat(Wallet, Roulette, SettingsMixin, commands.Cog, metaclass=Com
             embed.set_author(name=ctx.author, icon_url=ctx.author.display_avatar)
             return await ctx.send(embed=embed)
         modifier = roll()
-        stolen = random.randint(1, int(userbalance * modifier))
+        stolen = random.randint(1, int(userbalance * modifier)+1)
         embed = discord.Embed(
             colour=discord.Color.green(),
             description=f"You steal {user.name}'s wallet and find {humanize_number(stolen)} inside.",


### PR DESCRIPTION
This PR fixes a edge case which has a 1 in 20 change of hitting.
```py
Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.local/share/Red-DiscordBot/data/astra/cogs/CogManager/cogs/unbelievaboat/unbelievaboat.py", line 401, in rob
    stolen = random.randint(1, int(userbalance * modifier))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/random.py", line 362, in randint
    return self.randrange(a, b+1)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/random.py", line 345, in randrange
    raise ValueError("empty range for randrange() (%d, %d, %d)" % (istart, istop, width))
ValueError: empty range for randrange() (1, 1, 0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/bot.py", line 1350, in invoke
    await ctx.command.invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1029, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 244, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: ValueError: empty range for randrange() (1, 1, 0)
```