### PR TITLE
[Forward]: AttributeError fix.

### DIFF
--- a/forward/forward.py
+++ b/forward/forward.py
@@ -176,20 +176,22 @@ class Forward(commands.Cog):
         Separate version of [p]dm but allows for guild owners. This only works for users in the
         guild.
         """
-        em = discord.Embed(colour=discord.Colour.red(), description=message)
-
-        if ctx.bot.user.display_avatar:
-            em.set_author(
-                name=f"Message from {ctx.author} | {ctx.author.id}",
-                icon_url=ctx.bot.user.display_avatar,
-            )
-        else:
-            em.set_author(name=f"Message from {ctx.author} | {ctx.author.id}")
-
+        if user.id == ctx.bot.user.id:
+            await ctx.send("I can't send a DM to myself.")
+            return
+        em = discord.Embed(
+            colour=discord.Colour.red(),
+            description=message,
+        )
+        em.set_author(
+            name=f"Message from {ctx.author} | {ctx.author.id}",
+            icon_url=ctx.bot.user.display_avatar.url if ctx.bot.user.display_avatar else None,
+        )
         try:
             await user.send(embed=em)
         except discord.Forbidden:
             await ctx.send(
-                "Oops. I couldn't deliver your message to {}. They most likely have me blocked or DMs closed!"
+                f"Oops. I couldn't deliver your message to {user}. They most likely have me blocked or DMs closed!"
             )
+            return
         await ctx.send(f"Message delivered to {user}")

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -189,7 +189,7 @@ class Forward(commands.Cog):
         )
         try:
             await user.send(embed=em)
-        except discord.Forbidden:
+        except (discord.Forbidden, discord.HTTPException):
             await ctx.send(
                 f"Oops. I couldn't deliver your message to {user}. They most likely have me blocked or DMs closed!"
             )

--- a/giveaways/menu.py
+++ b/giveaways/menu.py
@@ -55,9 +55,7 @@ class GiveawayButton(Button):
                 log.exception("Error while adding user to giveaway", exc_info=e)
                 return
             except AlreadyEnteredError:
-                await interaction.followup.send(
-                    "You are already in the giveaway.", ephemeral=True
-                )
+                await interaction.followup.send("You are already in the giveaway.", ephemeral=True)
                 return
             await self.update_entrant(giveaway, interaction)
             await interaction.followup.send(


### PR DESCRIPTION
Fix `pm` command to safely handle self-targeting and DM failures

This resolves this AttributeError:
```py
#1775 [2026-02-25 07:27:30] ERROR [red] Exception in command 'pm'.
Traceback (most recent call last):
File "{HOME}/axion/lib/python3.11/site-packages/discord/ext/commands/core.py", line 266, in wrapped
ret = await coro(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/data/cogs/CogManager/cogs/forward/forward.py", line 190, in pm
await user.send(embed=em)
File "{HOME}/axion/lib/python3.11/site-packages/discord/abc.py", line 1653, in send
channel = await self._get_channel()
^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/discord/member.py", line 417, in _get_channel
ch = await self.create_dm()
^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/discord/member.py", line 195, in general
return await getattr(self._user, x)(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ClientUser' object has no attribute 'create_dm'
```