### PR TITLE
[Highlight]: Fix a 50007 error code when sending dm to an user.

### DIFF
--- a/highlight/highlight.py
+++ b/highlight/highlight.py
@@ -246,10 +246,18 @@ class Highlight(commands.Cog):
                 )
 
                 embed.add_field(name="Jump", value=f"[Click for context]({message.jump_url})")
-                await highlighted_usr.send(
-                    f"Your highlighted word{'s' if len(highlighted_words) > 1 else ''} {humanize_list(list(map(inline, highlighted_words)))} was mentioned in {message.channel.mention} by {message.author.display_name}.\n",
-                    embed=embed,
-                )
+                try:
+                    await highlighted_usr.send(
+                        f"Your highlighted word{'s' if len(highlighted_words) > 1 else ''} {humanize_list(list(map(inline, highlighted_words)))} was mentioned in {message.channel.mention} by {message.author.display_name}.\n",
+                        embed=embed,
+                    )
+                except discord.Forbidden:
+                    try:
+                        await message.channel.send(
+                            f"{highlighted_usr.mention} I tried to notify you but your DMs are closed."
+                        )
+                    except discord.Forbidden:
+                        pass
                 self.cooldowns[highlighted_usr.id] = datetime.now(tz=timezone.utc)
 
     def channel_check(self, ctx: commands.Context, channel: discord.TextChannel):


### PR DESCRIPTION
Solves #246
This PR is just wrapping the send method with try/except to avoid raising a 50007 error code by users that has blocked the bot, or has dms closed.
I have made the code send a message in the channel where user gets highlighted, so they can know their DMs are closed (most frequently). I didn't make it say that they blocked bot, since if they did block the bot, they won't really care or open the message..